### PR TITLE
Export a `.terminatePool()` function as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,13 +60,18 @@ module.exports = function (opt) {
     });
   };
 
-  // Useful for scripts, or graceful shutdown of server
-  self.close = function(cb) {
-    warn('closing connection pool');
+  /**
+   * Terminates the connection pool. No more `.query()` or `.getConnection()` calls will be honoured after this.
+   * Useful when terminating from within scripts, or trying to gracefully restart servers.
+   * See: https://www.npmjs.com/package/mysql#closing-all-the-connections-in-a-pool
+   * @param {Function} cb called when the pool is terminated. Is passed to node-mysql's `pool.end()`.
+   */
+  self.terminatePool = function(cb) {
+    warn('terminating connection pool');
 
     if (typeof cb !== 'function') {
       cb = function(err) {
-        if (err) warn ('error ocurred in closing connection pool:', err);
+        if (err) warn ('error ocurred in terminating connection pool:', err);
       };
     }
 

--- a/index.js
+++ b/index.js
@@ -62,8 +62,6 @@ module.exports = function (opt) {
 
   // Useful for scripts, or graceful shutdown of server
   self.close = function(cb) {
-    if (!pool) return cb();
-
     warn('closing connection pool');
 
     if (typeof cb !== 'function') {
@@ -71,6 +69,8 @@ module.exports = function (opt) {
         if (err) warn ('error ocurred in closing connection pool:', err);
       };
     }
+
+    if (!pool) return cb();
 
     pool.end(cb);
   };

--- a/index.js
+++ b/index.js
@@ -60,6 +60,21 @@ module.exports = function (opt) {
     });
   };
 
+  // Useful for scripts, or graceful shutdown of server
+  self.close = function(cb) {
+    if (!pool) return cb();
+
+    warn('closing connection pool');
+
+    if (typeof cb !== 'function') {
+      cb = function(err) {
+        if (err) warn ('error ocurred in closing connection pool:', err);
+      };
+    }
+
+    pool.end(cb);
+  };
+
   self.open();
 
   self.models = {};

--- a/test/test.js
+++ b/test/test.js
@@ -29,61 +29,76 @@ describe('Basic', function() {
       conn.release();
       done();
     });
-  })
+  });
 
   describe('#create pool', function() {
-   it('should do select with limits', function(done) {
-    infoSchema.select().limit(2).exec(function(err,rows) {
-      assert(err == undefined && rows.length == 2);
-      assert(rows[0].TABLE_SCHEMA == 'information_schema');
-      done();
-    });
-   });
-
-   it('should allow direct queries using .query', function(done) {
-    db.query('select * from tables limit 1', function(err,rows) {
-      assert(err == undefined && rows.length == 1);
-      assert(rows[0].TABLE_SCHEMA == 'information_schema');
-      done();
-    });
-   });
-
-   it('should allow to get a connection and run query on it', function(done) {
-    db.getConnection(function(err,connection) {
-      assert(err == undefined);
-      console.log('thread id ', connection.threadId);
-      connection.query('select * from tables limit 1', function(err,rows) {
-        assert(err == undefined && rows.length == 1);
+    it('should do select with limits', function(done) {
+      infoSchema.select().limit(2).exec(function(err,rows) {
+        assert(err == undefined && rows.length == 2);
         assert(rows[0].TABLE_SCHEMA == 'information_schema');
-        connection.release();
         done();
       });
     });
-   });
 
-   it('should return tooBusy when out of conns', function(done) {
-    db.getConnection(function(err,conn1) {
-      var tooBusyCalled = false;
-      console.log('blocked thread ', conn1.threadId);
-      db.getConnection(function(err,conn) {
-        console.log('blocked thread ', conn.threadId);
-        db.query('select * from tables limit 1',function(err,rows) {
-          assert(tooBusyCalled); // this callback will not be called.
-        });
-
-        var t = setTimeout(function() {
-          if (db.tooBusy(500)) {
-            console.log('too busy called');
-            clearTimeout(t);
-            tooBusyCalled = true;
-          }
-          conn.release();
-          conn1.release();
-          done();
-        },1500);
+    it('should allow direct queries using .query', function(done) {
+      db.query('select * from tables limit 1', function(err,rows) {
+        assert(err == undefined && rows.length == 1);
+        assert(rows[0].TABLE_SCHEMA == 'information_schema');
+        done();
+      });
     });
-   });
-  });
 
+    it('should allow to get a connection and run query on it', function(done) {
+      db.getConnection(function(err,connection) {
+        assert(err == undefined);
+        console.log('thread id ', connection.threadId);
+        connection.query('select * from tables limit 1', function(err,rows) {
+          assert(err == undefined && rows.length == 1);
+          assert(rows[0].TABLE_SCHEMA == 'information_schema');
+          connection.release();
+          done();
+        });
+      });
+    });
+
+    it('should return tooBusy when out of conns', function(done) {
+      db.getConnection(function(err,conn1) {
+        var tooBusyCalled = false;
+        console.log('blocked thread ', conn1.threadId);
+        db.getConnection(function(err,conn) {
+          console.log('blocked thread ', conn.threadId);
+          db.query('select * from tables limit 1',function(err,rows) {
+            assert(tooBusyCalled); // this callback will not be called.
+          });
+
+          var t = setTimeout(function() {
+            if (db.tooBusy(500)) {
+              console.log('too busy called');
+              clearTimeout(t);
+              tooBusyCalled = true;
+            }
+            conn.release();
+            conn1.release();
+            done();
+          },1500);
+        });
+      });
+    });
+
+    it('should allow to call .close() on db', function (done) {
+      // This test cannot be run along with the tooBusy test case (previous).
+      // Run them independently like so:
+      // `mocha test/test -i --fgrep 'tooBusy'` # to run all but tooBusy
+      // `mocha test/test -g 'close()'`         # to run only this test
+      db.close(function (err) {
+        console.log('db closed');
+        assert(err == undefined);
+        db.getConnection(function (err, conn) {
+          assert (err.message == 'Pool is closed.');
+          assert (conn == undefined);
+          done();
+        });
+      });
+    });
   });
-})
+});

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ describe('Basic', function() {
 
   before(function(done) {
     var dbConfig = { 
-      url: 'mysql://root:@:3306/information_schema',
+      url: 'mysql://root:paytm%40197@:3306/information_schema',
       connections: { min: 1, max: 2 }
     };
 
@@ -85,13 +85,13 @@ describe('Basic', function() {
       });
     });
 
-    it('should allow to call .close() on db', function (done) {
+    it('should allow to call .terminatePool() on db', function (done) {
       // This test cannot be run along with the tooBusy test case (previous).
       // Run them independently like so:
       // `mocha test/test -i --fgrep 'tooBusy'` # to run all but tooBusy
       // `mocha test/test -g 'close()'`         # to run only this test
-      db.close(function (err) {
-        console.log('db closed');
+      db.terminatePool(function (err) {
+        console.log('db connection pool terminated');
         assert(err == undefined);
         db.getConnection(function (err, conn) {
           assert (err.message == 'Pool is closed.');


### PR DESCRIPTION
As per
https://www.npmjs.com/package/mysql#closing-all-the-connections-in-a-pool,
we would need to call `.end()` on a mysql connection pool, otherwise
the node event loop will stay active until the mysql server closes the
connections.

Exposing this through a `.close()` function would be helpful for
scripts, crons, or gracefully restarting a webserver.

 Changes to be committed:
    modified:   index.js
    modified:   test/test.js
