### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "debug": "^2.1.3",
     "mysql": "^2.4.2",
-    "sql": "git://github.com/paytm/node-sql.git"
+    "sql": "https://github.com/paytm/node-sql.git"
   }
 }


### PR DESCRIPTION
To fix below error.
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t git://github.com/paytm/node-sql.git
npm ERR! 
npm ERR! fatal: remote error: 
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
npm ERR! Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
npm ERR! 
npm ERR! exited with error code: 128

npm ERR! A complete log of this run can be found in:
npm ERR!     /var/www-payoutsadmin/.npm/_logs/2022-01-11T11_32_24_415Z-debug.log

  NPM install failed  1